### PR TITLE
Changed persistent flag to be false

### DIFF
--- a/src/main/java/org/dasein/cloud/rackspace/compute/CloudServers.java
+++ b/src/main/java/org/dasein/cloud/rackspace/compute/CloudServers.java
@@ -711,7 +711,7 @@ public class CloudServers implements VirtualMachineSupport {
             vm.setLastBootTimestamp(-1L);
             vm.setLastPauseTimestamp(-1L);
             vm.setPausable(false);
-            vm.setPersistent(true);
+            vm.setPersistent(false);
             vm.setPlatform(Platform.UNKNOWN);
             vm.setRebootable(true);
             vm.setProviderOwnerId(provider.getContext().getAccountNumber());


### PR DESCRIPTION
So that the current Enstratius console can properly hide/show the pause functions for Rackspace VMs I've adjusted the .setPersistent flag for each VM.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/greese/dasein-cloud-rackspace/1)

<!-- Reviewable:end -->
